### PR TITLE
Signup page without copying the full wizard

### DIFF
--- a/app/models/wsjrdp_2027/wizards/steps/new_user_form.rb
+++ b/app/models/wsjrdp_2027/wizards/steps/new_user_form.rb
@@ -1,51 +1,22 @@
 # frozen_string_literal: true
 
-# Overwrite TODO is there something better?
-class Wizards::Steps::NewUserForm < Wizards::Step
+module Wsjrdp2027::Wizards::Steps::NewUserForm
+  extend ActiveSupport::Concern
+
   include BuddyIdHelper
 
-  attribute :first_name, :string
-  attribute :last_name, :string
-  attribute :nickname, :string
-  attribute :company_name, :string
-  attribute :company, :boolean
-  attribute :birthday, :date
-  attribute :email, :string
-  attribute :adult_consent, :boolean
-  attribute :privacy_policy_accepted, :boolean
-  attribute :buddy_id, :string
+  included do
+    attribute :birthday, :date
+    attribute :buddy_id, :string
 
-  validates :first_name, :last_name, :birthday, presence: true
-  validates :adult_consent, acceptance: true, if: :requires_adult_consent?
-  validates :company_name, presence: true, if: :company
-  validate :assert_privacy_policy, if: :requires_policy_acceptance?
-  validate :assert_role_policy
-  validate :assert_age_policy
-
-  delegate :requires_adult_consent?, :requires_policy_acceptance?, to: :wizard
-
-  class_attribute :support_company, default: true
+    validates :email, :birthday, presence: true
+    validate :assert_role_policy
+    validate :assert_age_policy
+  end
 
   def initialize(wizard, **params)
     params[:buddy_id] ||= get_random_spice
     super(wizard, **params)
-  end
-
-  def self.human_attribute_name(attr, options = {})
-    super(attr, default: Person.human_attribute_name(attr, options))
-  end
-
-  def assignable_attributes
-    attributes.compact_blank.symbolize_keys.except(:adult_consent)
-  end
-
-  private
-
-  def assert_privacy_policy
-    unless privacy_policy_accepted
-      message = I18n.t("groups.self_registration.create.flash.privacy_policy_not_accepted")
-      errors.add(:base, message)
-    end
   end
 
   def assert_role_policy

--- a/lib/hitobito_wsjrdp_2027/wagon.rb
+++ b/lib/hitobito_wsjrdp_2027/wagon.rb
@@ -19,6 +19,7 @@ module HitobitoWsjrdp2027
       Group.include Wsjrdp2027::Group
       Contactable.prepend Wsjrdp2027::Concerns::Contactable
       Sheet::Person.include Wsjrdp2027::Sheet::Person
+      Wizards::Steps::NewUserForm.include Wsjrdp2027::Wizards::Steps::NewUserForm
     end
 
     initializer 'wsjrdp_2027.add_settings' do |_app|


### PR DESCRIPTION
Replace the copied wizard with an included concern that contains just our additional logic. Also, make the email address a required field during signup as users without email will not be useful to us.

Draft, as I am not totally sure about testing. I verified that this still works:
- Birthday verification is executed (I saw some of our custom errors)
- User has a buddy id after signup

Plus, we might want to fix the age constraints for ULs